### PR TITLE
Accept payment on behalf of subMerchant

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -41,6 +41,11 @@ Api.prototype = {
     if (ids) { // path substitution
       args.path = ids;
     }
+
+    if(this._beanstream._config.subMerchantId){
+      args.headers['Sub-Merchant-Id'] = this._beanstream._config.subMerchantId;
+    }
+
     return args;
   },
 

--- a/lib/beanstream.js
+++ b/lib/beanstream.js
@@ -87,6 +87,11 @@ Beanstream.prototype = {
   getRequestUrl: function(timeout) {
     return this.getConfigField("host")+this.getConfigField("apiVersion")+"/";
   },
+
+  setSubMerchantId: function(merchantId) {
+    this._setConfigField("subMerchantId", merchantId);
+  },
+
 };
 
 module.exports = Beanstream;


### PR DESCRIPTION
As per "Bambora Payment APIs" specification for Version: 1.0.5, I have updated code to pass **Sub-Merchant-Id** in request header.

**How to use?**
You can set Sub Merchant Id with simple setter function
>  beanstream.setSubMerchantId(xxxxxxxxx);

See complete example
```
            let subMerchantId = 'xxxxxxxxx';
            let beanstream = require('beanstream-node')(config.BAMBORA.merchantId, config.BAMBORA.paymentsAPIKey)

            ** here you provide Sub Merchant Id **
            beanstream.setSubMerchantId(subMerchantId);

            let tokenPayment = {
                order_number: 'EA54321',
                amount: 1.00,
                payment_method: 'token',
                token: {
                    code: inputData.token,
                    complete: true,
                    name: 'Customer Test',
                }
            };
            beanstream.payments.makePayment(tokenPayment)
                .then(function(response) {
                    // successful payment
                    console.log("Payment response: ", response);
                    callback();
                })
                .catch(function(error) {
                    // all errors end up here, even declined payments
                    console.log("Payment response errors: ", error);
                    callback(error.message);
                });
```

